### PR TITLE
Couple more Readme formatting items

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ To use vrnetlab nodes on Containerlab WSL you must <u>ensure that nested virtual
 
 - You can do this by opening the *'WSL Settings'* app, going to the *'Optional features'* tab and ensuring *'Enable nested virtualization'* is enabled.
   
-  If you don't get any errors during installation or distro bootup saying that 'Nested virtualization is not supported on this machine.' You should be good to go.
+> [!NOTE]
+> You should be good to go if you don't get any errors during installation or
+> distro bootup saying that *'Nested virtualization is not supported on this
+> machine.'*
 
 See the [containerlab user manual](https://containerlab.dev/manual/vrnetlab/) for more information about vrnetlab.
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Despite the fairly generous resource allocation by default. WSL2 will not use 10
 If you have Docker desktop installed. You **must** ensure the integration with the Containerlab WSL distro is disabled, otherwise Containerlab will not work inside Containerlab WSL.
 
 1. Open Docker Desktop window and go to settings (gear icon on the title bar)
-2. Under the 'Resources tab, enter the 'WSL integration' page
-3. Ensure 'Containerlab' has integration disabled
+1. Under the 'Resources tab, enter the 'WSL integration' page
+1. Ensure 'Containerlab' has integration disabled
 
 ![](./images/docker_desktop_integration.png)
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Windows version: 10.0.19044.5131
 2. Double click the `.wsl` file to install the distribution.
 
 > [!NOTE]
-> You may see an error that nested virtualization is not supported. See the
+> If you see an error that nested virtualization is not supported, see the
 > [vrnetlab](#vrnetlab-nested-virtualization) section below.
 
 3. From the start menu you can launch the distribution from a new 'Containerlab' shortcut which has been added. 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ We recommend using Windows Terminal for the best experience:
 
 # WSL Installation
 
-This distro makes use of WSL2, which requires that virtualization is enabled in your UEFI/BIOS. 
+This distro makes use of WSL2, which requires that virtualization is enabled in
+your UEFI/BIOS. 
 
-This may appear as something called 'SVM (AMD-V)' or 'Intel VT-x' depending on your processor.
+This may appear as something called 'SVM (AMD-V)' or 'Intel VT-x' depending on
+your processor.
 
 ### Windows 11
 
@@ -63,9 +65,11 @@ dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux 
 dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
 ```
 
-At this point restart your computer. After it has rebooted download the latest WSL2 kernel. [Download link](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi).
+At this point restart your computer. After it has rebooted download the latest
+WSL2 kernel. [Download link](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi).
 
-Follow the installation wizard. After completion finally set WSL2 as the default version of WSL.
+Follow the installation wizard. After completion finally set WSL2 as the default
+version of WSL.
 
 In PowerShell or command prompt paste the following:
 
@@ -75,7 +79,8 @@ wsl --set-default-version 2
 
 ## Version Check
 
-Run `wsl --version` in PowerShell or command prompt to ensure WSL2 is enabled. The WSL version number should be 2.4.4.0 or higher.
+Run `wsl --version` in PowerShell or command prompt to ensure WSL2 is enabled.
+The WSL version number should be 2.4.4.0 or higher.
 
 ```powershell
 PS C:\Users\Kaelem> wsl --version
@@ -90,7 +95,8 @@ Windows version: 10.0.19044.5131
 
 # Distro Installation
 
-**Ensure WSL is enabled and you have WSL 2.4.4 or newer. See the [version check](#version-check) instructions.**
+**Ensure WSL is enabled and you have WSL 2.4.4 or newer. See the
+[version check](#version-check) instructions.**
 
 
 1. Download the `.wsl` file from the [latest release](https://github.com/kaelemc/wsl-clab/releases/latest).
@@ -101,7 +107,8 @@ Windows version: 10.0.19044.5131
 > If you see an error that nested virtualization is not supported, see the
 > [vrnetlab](#vrnetlab-nested-virtualization) section below.
 
-3. From the start menu you can launch the distribution from a new 'Containerlab' shortcut which has been added. 
+3. From the start menu you can launch the distribution from a new 'Containerlab'
+   shortcut which has been added.
 
     or in PowerShell/cmd you can execute:
 
@@ -109,16 +116,23 @@ Windows version: 10.0.19044.5131
     wsl -d Containerlab
     ```
 
-4. On first launch you will be presented with an interactive menu to select what shell and prompt you would like. 
+4. On first launch you will be presented with an interactive menu to select what
+   shell and prompt you would like. 
 
-    This menu will give you options of `zsh`, `bash` (with a fancy two-line prompt) or `bash` with the default prompt.
+    This menu will give you options of `zsh`, `bash` (with a fancy two-line prompt)
+    or `bash` with the default prompt.
 
-    You will also be presented with the choice to have the Fira Code [nerd font](https://www.nerdfonts.com/font-downloads) automatically installed on your system.
-    **We recommend you install this font (especially if using `zsh` as your shell of choice)**.
+    You will also be presented with the choice to have the Fira Code
+    [nerd font](https://www.nerdfonts.com/font-downloads) automatically installed on
+    your system. **We recommend you install this font (especially if using `zsh` as
+    your shell of choice).**
 
-    Finally at the end SSH keys will be copied from your Windows host into Containerlab WSL to enable passwordless SSH. This is an integral step for [DevPod](#devpod) usage.
+    Finally at the end SSH keys will be copied from your Windows host into
+    Containerlab WSL to enable passwordless SSH. This is an integral step for
+    [DevPod](#devpod) usage.
 
-    If no SSH keys are found on your machine, an RSA keypair will be automatically generated.
+    If no SSH keys are found on your machine, an RSA keypair will be automatically
+    generated.
 
     To run the setup again, execute `/etc/oobe.sh` inside Containerlab WSL.
 
@@ -146,18 +160,23 @@ Windows version: 10.0.19044.5131
 > [!IMPORTANT]
 > This feature is only supported on Windows 11.
 
-You can run [vrnetlab (VM-based)](https://github.com/hellt/vrnetlab) nodes on top of WSL2 and use them in containerlab. Containerlab WSL is already configured so that nested virtualization is enabled on the distro side.
+You can run [vrnetlab (VM-based)](https://github.com/hellt/vrnetlab) nodes on
+top of WSL2 and use them in containerlab. Containerlab WSL is already configured
+so that nested virtualization is enabled on the distro side.
 
-To use vrnetlab nodes on Containerlab WSL you must <u>ensure that nested virtualization is enabled globally in WSL</u>. 
+To use vrnetlab nodes on Containerlab WSL you must <u>ensure that nested
+virtualization is enabled globally in WSL</u>. 
 
-- You can do this by opening the *'WSL Settings'* app, going to the *'Optional features'* tab and ensuring *'Enable nested virtualization'* is enabled.
+- You can do this by opening the *'WSL Settings'* app, going to the *'Optional
+features'* tab and ensuring *'Enable nested virtualization'* is enabled.
   
 > [!NOTE]
 > You should be good to go if you don't get any errors during installation or
 > distro bootup saying that *'Nested virtualization is not supported on this
 > machine.'*
 
-See the [containerlab user manual](https://containerlab.dev/manual/vrnetlab/) for more information about vrnetlab.
+See the [containerlab user manual](https://containerlab.dev/manual/vrnetlab/)
+for more information about vrnetlab.
 
 # Performance Tuning
 
@@ -169,11 +188,14 @@ WSL2 runs as a VM. By default allocated resources are:
 | RAM          | 50% of system memory |                    If you have 32Gb of RAM on your system, WSL will allocate 16Gb to the WSL VM.                    |
 | Disk         | 1Tb                  | Regardless of disk size, the WSL VM will have a VHD with a maximum size of 1Tb. The disk is thin/sparse provisioned. |
 
-Despite the fairly generous resource allocation by default. WSL2 will not use 100% of the assigned resources.
+Despite the fairly generous resource allocation by default. WSL2 will not use
+100% of the assigned resources.
 
 # Docker Desktop
 
-If you have Docker desktop installed. You **must** ensure the integration with the Containerlab WSL distro is disabled, otherwise Containerlab will not work inside Containerlab WSL.
+If you have Docker desktop installed. You **must** ensure the integration with
+the Containerlab WSL distro is disabled, otherwise Containerlab will not work
+inside Containerlab WSL.
 
 1. Open Docker Desktop window and go to settings (gear icon on the title bar)
 1. Under the 'Resources tab, enter the 'WSL integration' page
@@ -183,24 +205,33 @@ If you have Docker desktop installed. You **must** ensure the integration with t
 
 # DevPod
 
-[DevPod](https://devpod.sh/) is an awesome tool which can let us easily run labs which take advantage of Devcontainers, which overall can give a 'one-click' lab experience. It's like running the codespaces labs but on your local machine.
+[DevPod](https://devpod.sh/) is an awesome tool which can let us easily run labs
+which take advantage of Devcontainers, which overall can give a 'one-click' lab
+experience. It's like running the codespaces labs but on your local machine.
 
-Check out [this video](https://www.youtube.com/watch?v=ceDrFx2K3jE) for more info.
+Check out [this video](https://www.youtube.com/watch?v=ceDrFx2K3jE) for more
+info.
 
-Containerlab WSL was designed to support this lab experience out of the box. Just remember the following consideration:
+Containerlab WSL was designed to support this lab experience out of the box.
+Just remember the following consideration:
 
-- When using DevPod, ensure Containerlab WSL is started (it does **not** automatically launch on Windows startup), you should leave the terminal window with Containerlab WSL open in the background.
+- When using DevPod, ensure Containerlab WSL is started (it does **not**
+automatically launch on Windows startup), you should leave the terminal window
+with Containerlab WSL open in the background.
 
-A one-time configuration step is required. You must setup a provider in DevPod. For Containerlab WSL, create the **SSH** provider with the following values:
+A one-time configuration step is required. You must setup a provider in DevPod.
+For Containerlab WSL, create the **SSH** provider with the following values:
 
 | Field | Value            |
 |-------|------------------|
 | Host  | `clab@localhost` |
 | Port  | `2222`           |
 
-You can leave the other settings as the default values. See the screenshot below.
+You can leave the other settings as the default values. See the screenshot
+below.
 
-After configuring the provider, you are done! You can now use one-click labs you see with the DevPod button, or configure the lab workspaces yourself.
+After configuring the provider, you are done! You can now use one-click labs you
+see with the DevPod button, or configure the lab workspaces yourself.
 
 ![DevPod settings screenshot](./images/devpod_settings.png)
 
@@ -208,13 +239,15 @@ After configuring the provider, you are done! You can now use one-click labs you
 
 Development should be performed from another WSL distribution.
 
-Clone the repository and build using the build script (you may have to `chmod +x` the script)
+Clone the repository and build using the build script (you may have to
+`chmod +x` the script)
 
 ```bash
 ./build.sh
 ```
 
-This will place `clab.wsl` in `C:\temp`. Doubleclick to install the distribution.
+This will place `clab.wsl` in `C:\temp`. Doubleclick to install the
+distribution.
 
 ## Manual Steps
 
@@ -242,7 +275,8 @@ This will place `clab.wsl` in `C:\temp`. Doubleclick to install the distribution
 
 4. Use it
   
-    In your windows filesystem at `C:\temp` should be a file `clab.wsl`, double click to install. or use:
+    In your windows filesystem at `C:\temp` should be a file `clab.wsl`, double
+    click to install. or use:
     
     ```powershell
     wsl --install --from-file clab.wsl
@@ -250,7 +284,8 @@ This will place `clab.wsl` in `C:\temp`. Doubleclick to install the distribution
 
 # Uninstallation
 
-Uninstall Containerlab WSL using the following command in PowerShell/command prompt:
+Uninstall Containerlab WSL using the following command in PowerShell/command
+prompt:
 
 ```powershell
 wsl --unregister Containerlab

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you have Docker desktop installed. You **must** ensure the integration with t
 1. Under the 'Resources tab, enter the 'WSL integration' page
 1. Ensure 'Containerlab' has integration disabled
 
-![](./images/docker_desktop_integration.png)
+![Docker Desktop integration screenshot](./images/docker_desktop_integration.png)
 
 # DevPod
 
@@ -201,7 +201,7 @@ You can leave the other settings as the default values. See the screenshot below
 
 After configuring the provider, you are done! You can now use one-click labs you see with the DevPod button, or configure the lab workspaces yourself.
 
-![](./images/devpod_settings.png)
+![DevPod settings screenshot](./images/devpod_settings.png)
 
 # Developers
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ docker run -t --name wsl_export ghcr.io/kaelemc/clab-wsl-debian ls /
 docker export wsl_export > /mnt/c/temp/clab.wsl
 ```
 
+> [!IMPORTANT]
 > Create the 'temp' directory on your C: drive if it doesn't exist.
 
 3. Remove the container to ease rebuilding:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A WSL distribution designed for easy 'plug and play' usage with [Containerlab](h
 > [Download](https://github.com/microsoft/WSL/releases/tag/2.4.4)
 
 
-|   **OS**   | **Supported** | **VM-based NOSes** |
-|:----------:|---------------|--------------------|
-| Windows 10 |      Yes      |         No         |
-| Windows 11 |      Yes      |         Yes        |
+|   OS       | Supported   | VM-based NOSes |
+| :--------: | :---------: | :------------: |
+| Windows 10 | Yes         | No             |
+| Windows 11 | Yes         | Yes            |
 
 We recommend using Windows Terminal for the best experience:
 - Windows 11 users: Windows Terminal is installed by default.
@@ -182,11 +182,11 @@ for more information about vrnetlab.
 
 WSL2 runs as a VM. By default allocated resources are:
 
-| **Resource** | **Default value**    | **Description**                                                                                                     |
-|:------------:|----------------------|---------------------------------------------------------------------------------------------------------------------|
-| vCPU         | Logical thread count |               If your processor has 8 cores and 16 threads, WSL2 will assign 16 threads to the WSL VM               |
-| RAM          | 50% of system memory |                    If you have 32Gb of RAM on your system, WSL will allocate 16Gb to the WSL VM.                    |
-| Disk         | 1Tb                  | Regardless of disk size, the WSL VM will have a VHD with a maximum size of 1Tb. The disk is thin/sparse provisioned. |
+| Resource | Default value        | Description |
+| :------: | -------------------- | :---------- |
+| vCPU     | Logical thread count | If your processor has 8 cores and 16 threads, WSL2 will assign 16 threads to the WSL VM. |
+| RAM      | 50% of system memory | If you have 32Gb of RAM on your system, WSL will allocate 16Gb to the WSL VM. |
+| Disk     | 1Tb                  | Regardless of disk size, the WSL VM will have a VHD with a maximum size of 1Tb. The disk is thin/sparse provisioned. |
 
 Despite the fairly generous resource allocation by default. WSL2 will not use
 100% of the assigned resources.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ This will place `clab.wsl` in `C:\temp`. Doubleclick to install the distribution
  docker build . --tag ghcr.io/kaelemc/clab-wsl-debian
 ```
 
-2. Run it and export the filesystem to a `.wsl.` file:
+2. Run it and export the filesystem to a `.wsl` file:
 
 ```bash
 docker run -t --name wsl_export ghcr.io/kaelemc/clab-wsl-debian ls /

--- a/README.md
+++ b/README.md
@@ -230,13 +230,13 @@ docker export wsl_export > /mnt/c/temp/clab.wsl
 
 > Create the 'temp' directory on your C: drive if it doesn't exist.
 
-Remove the container to ease rebuilding:
+3. Remove the container to ease rebuilding:
 
 ```bash
 docker rm wsl_export
 ```
 
-3. Use it
+4. Use it
   
 In your windows filesystem at `C:\temp` should be a file `clab.wsl`, double click to install. or use:
 

--- a/README.md
+++ b/README.md
@@ -264,5 +264,5 @@ wsl -l -v
 
 # Reference Material
 
-* https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro#export-the-tar-from-a-container
-* https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro
+- https://learn.microsoft.com/en-us/windows/wsl/use-custom-distro#export-the-tar-from-a-container
+- https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Windows version: 10.0.19044.5131
 
 1. Download the `.wsl` file from the [latest release](https://github.com/kaelemc/wsl-clab/releases/latest).
 
-2. Double click the `.wsl` file. This will install the distribution.
+2. Double click the `.wsl` file to install the distribution.
 
     > You may see an error that nested virtualization is not supported. See [vrnetlab](#vrnetlab-nested-virtualization).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We recommend using Windows Terminal for the best experience:
 - If you have Docker Desktop installed. See [Docker Desktop](#docker-desktop).
 - Done! you can start labbing. (see [DevPod](#devpod) for a great way to lab).
 
->[!NOTE]
+> [!NOTE]
 > Default credentials are `clab:clab`
 
 # WSL Installation
@@ -50,7 +50,7 @@ Restart your PC, and WSL2 should be installed.
 
 ### Windows 10
 
->[!TIP]
+> [!TIP]
 > Newer versions of Windows 10 allow usage of `wsl --install`, just like with Windows 11.
 
 **Instructions are from ['Manual installation steps for older versions of WSL'.](https://learn.microsoft.com/en-us/windows/wsl/install-manual)**
@@ -113,7 +113,8 @@ Windows version: 10.0.19044.5131
 
     This menu will give you options of `zsh`, `bash` (with a fancy two-line prompt) or `bash` with the default prompt.
 
-    You will also be presented with the choice to have the Fira Code [nerd font](https://www.nerdfonts.com/font-downloads) automatically installed on your system. **We recommend you install this font (especially if using `zsh` as your shell of choice)**.
+    You will also be presented with the choice to have the Fira Code [nerd font](https://www.nerdfonts.com/font-downloads) automatically installed on your system.
+    **We recommend you install this font (especially if using `zsh` as your shell of choice)**.
 
     Finally at the end SSH keys will be copied from your Windows host into Containerlab WSL to enable passwordless SSH. This is an integral step for [DevPod](#devpod) usage.
 
@@ -219,33 +220,33 @@ This will place `clab.wsl` in `C:\temp`. Doubleclick to install the distribution
 
 1. From inside a WSL distro Build the container:
 
-```bash
- docker build . --tag ghcr.io/kaelemc/clab-wsl-debian
-```
+    ```bash
+     docker build . --tag ghcr.io/kaelemc/clab-wsl-debian
+    ```
 
 2. Run it and export the filesystem to a `.wsl` file:
 
-```bash
-docker run -t --name wsl_export ghcr.io/kaelemc/clab-wsl-debian ls /
-docker export wsl_export > /mnt/c/temp/clab.wsl
-```
+    ```bash
+    docker run -t --name wsl_export ghcr.io/kaelemc/clab-wsl-debian ls /
+    docker export wsl_export > /mnt/c/temp/clab.wsl
+    ```
 
 > [!IMPORTANT]
 > Create the 'temp' directory on your C: drive if it doesn't exist.
 
 3. Remove the container to ease rebuilding:
 
-```bash
-docker rm wsl_export
-```
+    ```bash
+    docker rm wsl_export
+    ```
 
 4. Use it
   
-In your windows filesystem at `C:\temp` should be a file `clab.wsl`, double click to install. or use:
-
-```powershell
-wsl --install --from-file clab.wsl
-```
+    In your windows filesystem at `C:\temp` should be a file `clab.wsl`, double click to install. or use:
+    
+    ```powershell
+    wsl --install --from-file clab.wsl
+    ```
 
 # Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Windows version: 10.0.19044.5131
 
 2. Double click the `.wsl` file to install the distribution.
 
-    > You may see an error that nested virtualization is not supported. See [vrnetlab](#vrnetlab-nested-virtualization).
+> [!NOTE]
+> You may see an error that nested virtualization is not supported. See the
+> [vrnetlab](#vrnetlab-nested-virtualization) section below.
 
 3. From the start menu you can launch the distribution from a new 'Containerlab' shortcut which has been added. 
 


### PR DESCRIPTION
To go along with #8, here are a few more Readme formatting items.

* Change distro install grammar
* Fix `.wsl.` to remove the extra trailing period in the inline code fence
* Change "remove container" to a numeric list item
* Put the "temp" dir note into an Alert
* Change nested virt sentence structure
* (later) Move nested virt into an Alert
* (later) Again change the nested virt sentence structure
* Added a space after the greater than symbol in the Alert syntax `> [!NOTE]`
* Standardize unordered list items to hyphens (fix bullets I probably set earlier :neutral_face:, oops)
* Give images a name (as an added plus, it should aid in web page accessibility for anyone with a screen reader)
* Indent some sub-content ([except Alerts](https://github.com/orgs/community/discussions/118296)) beneath related bullet points
* Lint some long Markdown lines
* Reformat Markdown tables based on the [GitHub docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)

I do have a question about numeric list items which I'll add as a PR response below.